### PR TITLE
Add user redirect back after login

### DIFF
--- a/config/sync/system.site.yml
+++ b/config/sync/system.site.yml
@@ -3,7 +3,7 @@ name: 'Islandora 8'
 mail: admin@example.com
 slogan: ''
 page:
-  403: ''
+  403: '/user/login?destination=document.location.pathname'
   404: ''
   front: /node/6
 admin_compact_mode: false


### PR DESCRIPTION
Something kinda annoying trying to go to a page you don't have access to. Normally the user should get a 403 page. This isn't set yet. I added a redirect to the login page and a "destination" to go back to the page that originally triggered the 403 page. 